### PR TITLE
Add logging capability using LibLog

### DIFF
--- a/VRChatApi/TestClient/ColoredConsoleLogProvider.cs
+++ b/VRChatApi/TestClient/ColoredConsoleLogProvider.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VRChatApi.Logging;
+using VRChatApi.Logging.LogProviders;
+
+namespace TestClient
+{
+    public class ColoredConsoleLogProvider : ILogProvider
+    {
+        private static readonly Dictionary<LogLevel, ConsoleColor> Colors = new Dictionary<LogLevel, ConsoleColor>
+            {
+                {LogLevel.Fatal, ConsoleColor.Red},
+                {LogLevel.Error, ConsoleColor.Yellow},
+                {LogLevel.Warn, ConsoleColor.Magenta},
+                {LogLevel.Info, ConsoleColor.White},
+                {LogLevel.Debug, ConsoleColor.Gray},
+                {LogLevel.Trace, ConsoleColor.DarkGray},
+            };
+
+        private readonly Lazy<OpenNdc> _lazyOpenNdcMethod;
+        private readonly Lazy<OpenMdc> _lazyOpenMdcMethod;
+        
+        public Logger GetLogger(string name)
+        {
+            return (logLevel, messageFunc, exception, formatParameters) =>
+            {
+                if (messageFunc == null)
+                {
+                    return true; // All log levels are enabled
+                }
+
+                if (Colors.TryGetValue(logLevel, out ConsoleColor consoleColor))
+                {
+                    var originalForground = Console.ForegroundColor;
+                    try
+                    {
+                        Console.ForegroundColor = consoleColor;
+                        WriteMessage(logLevel, name, messageFunc, formatParameters, exception);
+                    }
+                    finally
+                    {
+                        Console.ForegroundColor = originalForground;
+                    }
+                }
+                else
+                {
+                    WriteMessage(logLevel, name, messageFunc, formatParameters, exception);
+                }
+
+                return true;
+            };
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            return _lazyOpenNdcMethod.Value(message);
+        }
+
+        public IDisposable OpenMappedContext(string key, object value, bool destructure = false)
+        {
+            return _lazyOpenMdcMethod.Value(key, value, destructure);
+        }
+
+        protected delegate IDisposable OpenNdc(string message);
+
+        protected delegate IDisposable OpenMdc(string key, object value, bool destructure);
+
+        private static void WriteMessage(
+            LogLevel logLevel,
+            string name,
+            Func<string> messageFunc,
+            object[] formatParameters,
+            Exception exception)
+        {
+            //var message = string.Format(CultureInfo.InvariantCulture, messageFunc(), formatParameters);
+            var message = messageFunc();
+            if (exception != null)
+            {
+                message = message + "|" + exception;
+            }
+            Console.WriteLine($"{DateTime.UtcNow} | {logLevel} | {name} | {message}");
+        }
+    }
+}

--- a/VRChatApi/TestClient/Program.cs
+++ b/VRChatApi/TestClient/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using VRChatApi;
@@ -13,6 +12,7 @@ namespace TestClient
         static async Task Main(string[] args)
         {
             VRChatApi.VRChatApi api = new VRChatApi.VRChatApi("username", "password");
+            VRChatApi.Logging.LogProvider.SetCurrentLogProvider(new ColoredConsoleLogProvider());
 
             // remote config
             ConfigResponse config = await api.RemoteConfig.Get();

--- a/VRChatApi/VRChatApi/Endpoints/AvatarApi.cs
+++ b/VRChatApi/VRChatApi/Endpoints/AvatarApi.cs
@@ -6,20 +6,27 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 namespace VRChatApi.Endpoints
 {
     public class AvatarApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public async Task<AvatarResponse> GetById(string id)
         {
+            Logger.Debug(() => $"Getting avatar details using ID: {id}");
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"avatars/{id}?apiKey={Global.ApiKey}");
 
             AvatarResponse res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<AvatarResponse>(await response.Content.ReadAsStringAsync());
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+
+                res = JsonConvert.DeserializeObject<AvatarResponse>(json);
             }
 
             return res;

--- a/VRChatApi/VRChatApi/Endpoints/FriendsApi.cs
+++ b/VRChatApi/VRChatApi/Endpoints/FriendsApi.cs
@@ -6,20 +6,27 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 namespace VRChatApi.Endpoints
 {
     public class FriendsApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public async Task<List<UserBriefResponse>> Get(int offset = 0, int count = 20, bool offline = false)
         {
+            Logger.Debug(() => $"Getting friends with {nameof(offset)} = {offset}, {nameof(count)} = {count}, {nameof(offline)} = {offline}");
+
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"auth/user/friends?apiKey={Global.ApiKey}&offset={offset}&n={count}&offline={offline.ToString().ToLowerInvariant()}");
 
             List<UserBriefResponse> res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<List<UserBriefResponse>>(await response.Content.ReadAsStringAsync());
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<List<UserBriefResponse>>(json);
             }
 
             return res;
@@ -27,21 +34,27 @@ namespace VRChatApi.Endpoints
 
         public async Task<NotificationResponse> SendRequest(string userId, string fromWho)
         {
+            Logger.Debug(() => $"Sending friend request to {userId} from {fromWho}");
             JObject json = new JObject();
             json["type"] = "friendrequest";
             json["message"] = $"{fromWho} wants to be your friend";
+
+            Logger.Debug(() => $"Prepared JSON to post: {json}");
 
             StringContent content = new StringContent(json.ToString(), Encoding.UTF8);
 
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
             HttpResponseMessage response = await Global.HttpClient.PostAsync($"user/{userId}/notification?apiKey={Global.ApiKey}", content);
+            
 
             NotificationResponse res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<NotificationResponse>(await response.Content.ReadAsStringAsync());
+                var receivedJson = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {receivedJson}");
+                res = JsonConvert.DeserializeObject<NotificationResponse>(receivedJson);
             }
 
             return res;
@@ -56,7 +69,9 @@ namespace VRChatApi.Endpoints
 
             if (response.IsSuccessStatusCode)
             {
-                res = await response.Content.ReadAsStringAsync();
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = json;
             }
 
             return res;

--- a/VRChatApi/VRChatApi/Endpoints/ModerationsApi.cs
+++ b/VRChatApi/VRChatApi/Endpoints/ModerationsApi.cs
@@ -6,20 +6,26 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 namespace VRChatApi.Endpoints
 {
     public class ModerationsApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public async Task<List<PlayerModeratedResponse>> GetPlayerModerations()
         {
+            Logger.Trace(() => "Get list of moderations made by current user");
             HttpResponseMessage response = await Global.HttpClient.GetAsync("auth/user/playermoderations");
 
             List<PlayerModeratedResponse> res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<List<PlayerModeratedResponse>>(await response.Content.ReadAsStringAsync());
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<List<PlayerModeratedResponse>>(json);
             }
 
             return res;
@@ -27,13 +33,16 @@ namespace VRChatApi.Endpoints
 
         public async Task<List<PlayerModeratedResponse>> GetPlayerModerated()
         {
+            Logger.Trace(() => "Get list of moderations made against current user");
             HttpResponseMessage response = await Global.HttpClient.GetAsync("auth/user/playermoderated");
 
             List<PlayerModeratedResponse> res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<List<PlayerModeratedResponse>>(await response.Content.ReadAsStringAsync());
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<List<PlayerModeratedResponse>>(json);
             }
 
             return res;

--- a/VRChatApi/VRChatApi/Endpoints/RemoteConfig.cs
+++ b/VRChatApi/VRChatApi/Endpoints/RemoteConfig.cs
@@ -1,22 +1,30 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 namespace VRChatApi.Endpoints
 {
     public class RemoteConfig
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public async Task<ConfigResponse> Get()
         {
+            Logger.Trace(() => "Getting remote config");
             HttpResponseMessage response = await Global.HttpClient.GetAsync("config");
 
             ConfigResponse res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<ConfigResponse>(await response.Content.ReadAsStringAsync());
+                var json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<ConfigResponse>(json);
                 Global.ApiKey = res.clientApiKey;
+                Logger.Info(() => $"API key has been set to: {Global.ApiKey}");
             }
 
             return res;

--- a/VRChatApi/VRChatApi/Endpoints/UserApi.cs
+++ b/VRChatApi/VRChatApi/Endpoints/UserApi.cs
@@ -7,22 +7,27 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 namespace VRChatApi.Endpoints
 {
     public class UserApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public string Username { get; set; }
         public string Password { get; set; }
 
         public UserApi(string username, string password)
         {
+            Logger.Trace(() => $"Entering {nameof(UserApi)} constructor with username: {username}");
             Username = username;
             Password = password;
         }
 
         public async Task<UserResponse> Login()
         {
+            Logger.Trace(() => "Getting current user details");
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"auth/user?apiKey={Global.ApiKey}");
 
             UserResponse res = null;
@@ -30,6 +35,7 @@ namespace VRChatApi.Endpoints
             if (response.IsSuccessStatusCode)
             {
                 string json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
                 res = JsonConvert.DeserializeObject<UserResponse>(json);
             }
 
@@ -38,6 +44,7 @@ namespace VRChatApi.Endpoints
 
         public async Task<UserResponse> Register(string username, string password, string email, string birthday = null, string acceptedTOSVersion = null)
         {
+            Logger.Debug(() => $"Registering new user with {nameof(username)} = {username}, {nameof(email)} = {email}, {nameof(birthday)} = {birthday}, {nameof(acceptedTOSVersion)} = {acceptedTOSVersion}");
             JObject json = new JObject();
             json["username"] = username;
             json["password"] = password;
@@ -51,6 +58,8 @@ namespace VRChatApi.Endpoints
             if (acceptedTOSVersion != null)
                 json["acceptedTOSVersion"] = acceptedTOSVersion;
 
+            Logger.Debug(() => $"Prepared JSON to post: {json}");
+
             StringContent content = new StringContent(json.ToString(), Encoding.UTF8);
 
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
@@ -61,7 +70,9 @@ namespace VRChatApi.Endpoints
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<UserResponse>(await response.Content.ReadAsStringAsync());
+                var receivedJson = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {receivedJson}");
+                res = JsonConvert.DeserializeObject<UserResponse>(receivedJson);
             }
 
             return res;
@@ -69,6 +80,7 @@ namespace VRChatApi.Endpoints
 
         public async Task<UserBriefResponse> GetById(string userId)
         {
+            Logger.Debug(() => $"Getting user info with ID: {userId}");
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"users/{userId}?apiKey={Global.ApiKey}");
 
             UserBriefResponse res = null;
@@ -76,6 +88,7 @@ namespace VRChatApi.Endpoints
             if (response.IsSuccessStatusCode)
             {
                 string json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
                 res = JsonConvert.DeserializeObject<UserBriefResponse>(json);
             }
 
@@ -84,6 +97,7 @@ namespace VRChatApi.Endpoints
 
         public async Task<UserResponse> UpdateInfo(string userId, string email = null, string birthday = null, string acceptedTOSVersion = null, List<string> tags = null)
         {
+            Logger.Debug(() => $"Updating user info for {nameof(userId)} = {userId} with {nameof(email)} = {email}, {nameof(birthday)} = {birthday}, {nameof(acceptedTOSVersion)} = {acceptedTOSVersion}, {nameof(tags)} = {tags}");
             JObject json = new JObject();
 
             if (email != null)
@@ -98,6 +112,8 @@ namespace VRChatApi.Endpoints
             if (tags != null)
                 json["tags"] = JToken.FromObject(tags);
 
+            Logger.Debug(() => $"Prepared JSON to put: {json}");
+
             StringContent content = new StringContent(json.ToString(), Encoding.UTF8);
 
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
@@ -108,7 +124,9 @@ namespace VRChatApi.Endpoints
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<UserResponse>(await response.Content.ReadAsStringAsync());
+                var receivedJson = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {receivedJson}");
+                res = JsonConvert.DeserializeObject<UserResponse>(receivedJson);
             }
 
             return res;

--- a/VRChatApi/VRChatApi/Endpoints/WorldAPI.cs
+++ b/VRChatApi/VRChatApi/Endpoints/WorldAPI.cs
@@ -8,21 +8,28 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using VRChatApi.Classes;
+using VRChatApi.Logging;
 
 
 namespace VRChatApi.Endpoints
 {
     public class WorldApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public async Task<WorldResponse> Get(string id)
         {
+            Logger.Debug(() => $"Getting world info with ID: {id}");
+
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"worlds/{id}?apiKey={Global.ApiKey}");
 
             WorldResponse res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<WorldResponse>(await response.Content.ReadAsStringAsync());
+                string json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<WorldResponse>(json);
                 
                 // Parse instances.
                 res.instances = res._instances.Select(data => new WorldInstance()
@@ -40,6 +47,7 @@ namespace VRChatApi.Endpoints
             string userId = null, string keyword = null, string tags = null, string excludeTags = null,
             ReleaseStatus? releaseStatus = null, int offset = 0, int count = 20)
         {
+            Logger.Debug(() => "Getting world list");
             var param = new StringBuilder();
             param.Append($"&n={count}");
             param.Append($"&offset={offset}");
@@ -100,7 +108,9 @@ namespace VRChatApi.Endpoints
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<List<WorldBriefResponse>>(await response.Content.ReadAsStringAsync());
+                string json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<List<WorldBriefResponse>>(json);
             }
 
             return res;
@@ -108,13 +118,16 @@ namespace VRChatApi.Endpoints
 
         public async Task<WorldMetadataResponse> GetMetadata(string id)
         {
+            Logger.Debug(() => $"Getting world metadata with ID: {id}");
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"worlds/{id}/metadata?apiKey={Global.ApiKey}");
 
             WorldMetadataResponse res = null;
 
             if (response.IsSuccessStatusCode)
             {
-                res = JsonConvert.DeserializeObject<WorldMetadataResponse>(await response.Content.ReadAsStringAsync());
+                string json = await response.Content.ReadAsStringAsync();
+                Logger.Debug(() => $"JSON received: {json}");
+                res = JsonConvert.DeserializeObject<WorldMetadataResponse>(json);
             }
 
             return res;
@@ -122,6 +135,7 @@ namespace VRChatApi.Endpoints
 
         public async Task<WorldInstanceResponse> GetInstance(string worldId, string instanceId)
         {
+            Logger.Debug(() => $"Getting world instance with world ID: {worldId} and instance ID {instanceId}");
             HttpResponseMessage response = await Global.HttpClient.GetAsync($"worlds/{worldId}/{instanceId}?apiKey={Global.ApiKey}");
 
             WorldInstanceResponse res = null;
@@ -129,7 +143,7 @@ namespace VRChatApi.Endpoints
             if (response.IsSuccessStatusCode)
             {
                 string text = await response.Content.ReadAsStringAsync();
-
+                Logger.Debug(() => $"JSON received: {text}");
                 var json = JObject.Parse(text);
 
                 res = new WorldInstanceResponse

--- a/VRChatApi/VRChatApi/VRChatApi.cs
+++ b/VRChatApi/VRChatApi/VRChatApi.cs
@@ -2,11 +2,14 @@
 using System.Net.Http;
 using System.Text;
 using VRChatApi.Endpoints;
+using VRChatApi.Logging;
 
 namespace VRChatApi
 {
     public class VRChatApi
     {
+        private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
+
         public RemoteConfig RemoteConfig { get; set; }
         public UserApi UserApi { get; set; }
         public FriendsApi FriendsApi { get; set; }
@@ -16,6 +19,9 @@ namespace VRChatApi
 
         public VRChatApi(string username, string password)
         {
+            Logger.Trace(() => $"Entering {nameof(VRChatApi)} constructor");
+            Logger.Debug(() => $"Using username {username}");
+
             // initialize endpoint classes
             RemoteConfig = new RemoteConfig();
             UserApi = new UserApi(username, password);
@@ -28,8 +34,10 @@ namespace VRChatApi
             // TODO: use the auth cookie
             if (Global.HttpClient == null)
             {
+                Logger.Trace(() => $"Instantiating {nameof(HttpClient)}");
                 Global.HttpClient = new HttpClient();
                 Global.HttpClient.BaseAddress = new Uri("https://api.vrchat.cloud/api/1/");
+                Logger.Info(() => $"VRChat API base address set to {Global.HttpClient.BaseAddress}");
             }
 
             string authEncoded = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{UserApi.Username}:{UserApi.Password}"));
@@ -37,9 +45,11 @@ namespace VRChatApi
             var header = Global.HttpClient.DefaultRequestHeaders;
             if (header.Contains("Authorization"))
             {
+                Logger.Debug(() => "Removing existing Authorization header");
                 header.Remove("Authorization");
             }
             header.Add("Authorization", $"Basic {authEncoded}");
+            Logger.Trace(() => $"Added new Authorization header");
         }
     }
 }

--- a/VRChatApi/VRChatApi/VRChatApi.csproj
+++ b/VRChatApi/VRChatApi/VRChatApi.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibLog" Version="5.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
which has built-in support for NLog, Log4Net, Serilog and Loupe, so any consumers can have the library logged through their own logging library of choice.

A custom console logger has been added to TestClient project based on https://github.com/damianh/LibLog/blob/c21fbcda9638188f922d2b42e56635cd54a2d0d6/src/LibLog.Example.ColoredConsoleLogProvider/ColoredConsoleLogProvider.cs